### PR TITLE
Typo In README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ Installation
 
 ::
 
-  $ python shiva/indexer.py
+  $ python indexer.py
 
 * Run the server:
 


### PR DESCRIPTION
indexer is in base directory /foo/bar/shiva-server/indexer.py not /foo/bar/shiva-server/shiva/indexer.py
