### PR TITLE
Fixed slug clashes when indexing a lot of files

### DIFF
--- a/indexer.py
+++ b/indexer.py
@@ -34,6 +34,8 @@ class Indexer(object):
         self.use_lastfm = use_lastfm
         self.no_metadata = no_metadata
 
+        self.count = 0
+
         self.session = db.session
         self.media_dirs = config.get('MEDIA_DIRS', [])
         self.id3r = None
@@ -159,6 +161,10 @@ class Indexer(object):
     def walk(self, dir_name):
         """Recursively walks through a directory looking for tracks.
         """
+
+        self.count += 1
+        if self.count % 10 == 0:
+          self.session.commit()
 
         if os.path.isdir(dir_name):
             for name in os.listdir(dir_name):


### PR DESCRIPTION
When indexing a couple thousand files at once it might lead to duplicate slugs
and since the database transaction is just commited at the end the "check in db if slug exists" thing does not work.

I added committing every 10 directories when indexing which fixed the problem for me.
