### PR TITLE
New `ignored(*exceptions)` context manager in utils.py

### DIFF
--- a/shiva/config/__init__.py
+++ b/shiva/config/__init__.py
@@ -9,6 +9,7 @@ import logging
 import traceback
 
 from shiva.config.project import *
+from shiva.utils import ignored
 try:
     # Rename the file local.py.example to local.py and edit it.
     from shiva.config.local import *
@@ -16,7 +17,5 @@ except ImportError:
     print(traceback.format_exc())
     logging.warning("Couldn't find local settings.")
 if DEBUG:
-    try:
+    with ignored(ImportError):
         from shiva.config.debug import *
-    except ImportError:
-        pass

--- a/shiva/utils.py
+++ b/shiva/utils.py
@@ -2,6 +2,7 @@
 import os
 from random import random
 from hashlib import md5
+from contextlib import contextmanager
 
 
 def randstr(length=None):
@@ -28,6 +29,16 @@ def _import(class_path):
     mod = __import__(mod_name, None, None, cls_name)
 
     return getattr(mod, cls_name)
+
+
+@contextmanager
+def ignored(*exceptions):
+    """Context manager that ignores all of the specified exceptions. This will
+    be in the standard library starting with Python 3.4."""
+    try:
+        yield
+    except exceptions:
+        pass
 
 
 class ID3Manager(object):


### PR DESCRIPTION
More idiomatic way to write the `try-except-pass` pattern using a context manager.

Taken from [this talk](pyvideo.org/video/1780/transforming-code-into-beautiful-idiomatic-pytho). This will be in Python 3.4's stdlib.
