### PR TITLE
make bitrate optional

### DIFF
--- a/shiva/utils.py
+++ b/shiva/utils.py
@@ -168,7 +168,8 @@ class MetadataManager(object):
     @property
     def bitrate(self):
         """The audio bitrate."""
-        return self.reader.info.bitrate
+        if hasattr(self.reader.info, 'bitrate'):
+            return self.reader.info.bitrate
 
     @property
     def sample_rate(self):


### PR DESCRIPTION
Some of my tracks do not have a bitrate set. I believe the field is a nice to have but not required to index. This commit makes it optional.
