### PR TITLE
Documented how to override the default DB

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,6 @@ Why Shiva?
 ----------
 
 Shiva is the name of the `crater <https://en.wikipedia.org/wiki/Shiva_crater>`_
-that would have been created by the
-`K-Pg event <https://en.wikipedia.org/wiki/Cretaceous%E2%80%93Paleogene_extinction_event>`_
+that would have been created by the `K-Pg event
+<https://en.wikipedia.org/wiki/Cretaceous%E2%80%93Paleogene_extinction_event>`_
 that extincted the `dinosaurs <https://www.youtube.com/watch?v=dlAeN3Qxlvc>`_.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -45,3 +45,14 @@ Then Shiva will also try to load this configuration files:
 
 In this case ``$XDG_CONFIG_HOME/shiva/debug.py`` will also have precedence over
 ``config/debug.py``.
+
+
+Database
+--------
+
+By default shiva uses sqlite because of its ease of setup and use, but if you
+have a different requirement you can override the ``SQLALCHEMY_DATABASE_URI``
+setting in your ``local.py`` file and use any of the `supported databases
+<http://docs.sqlalchemy.org/en/rel_0_5/dbengine.html#supported-databases>`_.
+
+Make sure that you have the proper database adapter installed.

--- a/shiva/config/local.py.example
+++ b/shiva/config/local.py.example
@@ -1,8 +1,15 @@
 # -*- coding: utf-8 -*-
+"""
+Shiva's configuration file. Here you can override Shiva's default values to fit
+your needs. For more information please read the `documentation
+<http://shiva.readthedocs.org/en/latest/configuration.html>_`.
+"""
 from shiva.media import MediaDir, MimeType
 
 SERVER_URI = ''
 SECRET_KEY = ''  # Set this to something secret.
+
+SQLALCHEMY_DATABASE_URI = 'sqlite:///shiva.db'
 
 # Require validation to access Shiva.
 ALLOW_ANONYMOUS_ACCESS = False


### PR DESCRIPTION
This means:
* The setting `SQLALCHEMY_DATABASE_URI` was added to `local.py.example`.
* A new section, "Database", was added to the documentation.
* A comment was added to `local.py.example` pointing to the
  documentation.